### PR TITLE
Move where posts are fetched to outside the class.

### DIFF
--- a/includes/class-mf2-feed-entry.php
+++ b/includes/class-mf2-feed-entry.php
@@ -21,11 +21,6 @@ class Mf2_Feed_Entry {
 	public $comment = array();
 
 	public function __construct( $post, $with_comments = false ) {
-		$post = get_post( $post );
-		if ( ! $post ) {
-			return false;
-		}
-
 		$this->_id              = $post->ID;
 		$this->type             = 'entry';
 		$this->name             = $post->post_name;

--- a/mf2-feed.php
+++ b/mf2-feed.php
@@ -85,10 +85,10 @@ class Mf2Feed {
 
 			while ( have_posts() ) {
 				the_post();
+				global $post;
+				$thepost = new Mf2_Feed_Entry( $post );
 
-				$post = new Mf2_Feed_Entry( get_the_ID() );
-
-				$items['items'][0]['children'][] = current( $post->to_mf2() );
+				$items['items'][0]['children'][] = current( $thepost->to_mf2() );
 			}
 		}
 

--- a/mf2-feed.php
+++ b/mf2-feed.php
@@ -57,8 +57,13 @@ class Mf2Feed {
 	public static function do_feed_mf2( $for_comments ) {
 		require_once dirname( __FILE__ ) . '/includes/class-mf2-feed-entry.php';
 
+		$thepost = get_post( get_the_ID() );
+		if ( ! $thepost ) {
+			return false;
+		}
+
 		if ( $for_comments ) {
-			$post = new Mf2_Feed_Entry( get_the_ID() );
+			$post = new Mf2_Feed_Entry( $thepost );
 
 			$post = $post->to_mf2();
 
@@ -118,8 +123,13 @@ class Mf2Feed {
 	public static function do_feed_jf2( $for_comments ) {
 		require_once dirname( __FILE__ ) . '/includes/class-mf2-feed-entry.php';
 
+		$thepost = get_post( get_the_ID() );
+		if ( ! $thepost ) {
+			return false;
+		}
+
 		if ( $for_comments ) {
-			$post = new Mf2_Feed_Entry( get_the_ID(), $for_comments );
+			$post = new Mf2_Feed_Entry( $thepost, $for_comments );
 			$items = $post->to_jf2();
 		} else {
 			$items = array( 'type' => 'feed' );


### PR DESCRIPTION
Used `$thepost` as a variable name because there is chance we could conflict with the `$post` global from WordPress. In one case, we fetch that global and use that for our parameter.