### PR TITLE
Refactor and Update of Plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,10 +26,6 @@ matrix:
   - php: 5.6
   - php: 5.6
     env: WP_PULUGIN_DEPLOY=1
-  - php: 5.5
-  - php: 5.4
-  - php: 5.3
-    dist: precise
 before_script:
 - |
   # Remove Xdebug for a huge performance increase:

--- a/includes/class-mf2-feed-entry.php
+++ b/includes/class-mf2-feed-entry.php
@@ -88,11 +88,11 @@ class Mf2_Feed_Entry {
 	 * @param bool $stripteaser Optional. Strip teaser content before the more text. Default is false.
 	 */
 	private function get_content_by_id( $post_id = 0, $more_link_text = null, $stripteaser = false ) {
-		global $post;
-		$post = get_post( $post_id );
-		setup_postdata( $post, $more_link_text, $stripteaser );
+		if ( ! $post_id ) {
+			$post_id = get_the_ID();
+		}
+		$post    = get_post( $post_id );
 		$content = get_the_content();
-		wp_reset_postdata( $post );
 
 		return $content;
 	}
@@ -106,11 +106,11 @@ class Mf2_Feed_Entry {
 	 * @param bool $stripteaser Optional. Strip teaser content before the more text. Default is false.
 	 */
 	private function get_excerpt_by_id( $post_id = 0, $more_link_text = null, $stripteaser = false ) {
-		global $post;
-		$post = get_post( $post_id );
-		setup_postdata( $post, $more_link_text, $stripteaser );
+		if ( ! $post_id ) {
+			$post_id = get_the_ID();
+		}
+		$post    = get_post( $post_id );
 		$content = get_the_excerpt();
-		wp_reset_postdata( $post );
 
 		return $content;
 	}

--- a/includes/class-mf2-feed-entry.php
+++ b/includes/class-mf2-feed-entry.php
@@ -34,16 +34,16 @@ class Mf2_Feed_Entry {
 		if ( $this->name = $this->_id ) {
 			$this->name = null;
 		}
-		$this->published        = get_post_time( DATE_W3C, false, $post );
-		$this->updated          = get_post_modified_time( DATE_W3C, false, $post );
-		$content = get_the_content( null, false, $post );
+		$this->published = get_post_time( DATE_W3C, false, $post );
+		$this->updated   = get_post_modified_time( DATE_W3C, false, $post );
+		$content         = get_the_content( null, false, $post );
 		if ( ! empty( $content ) ) {
 			$this->content['html']  = get_the_content( null, false, $post );
 			$this->content['value'] = wp_strip_all_tags( $this->content['html'] );
 		}
-		$this->summary          = get_the_excerpt( $post );
-		$this->url              = get_permalink( $post );
-		$this->uid              = get_permalink( $post );
+		$this->summary = get_the_excerpt( $post );
+		$this->url     = get_permalink( $post );
+		$this->uid     = get_permalink( $post );
 
 		// Get a list of categories and extract their names
 		$post_categories = get_the_terms( $post->ID, 'category' );

--- a/includes/class-mf2-feed-entry.php
+++ b/includes/class-mf2-feed-entry.php
@@ -11,6 +11,7 @@ class Mf2_Feed_Entry {
 	public $type;
 	public $name;
 	public $url;
+	public $uid;
 	public $author = array();
 	public $published;
 	public $updated;
@@ -26,15 +27,23 @@ class Mf2_Feed_Entry {
 			return false;
 		}
 
-		$this->_id              = $post->ID;
-		$this->type             = 'entry';
-		$this->name             = $post->post_name;
-		$this->published        = mysql2date( DATE_W3C, $post->post_date );
-		$this->updated          = mysql2date( DATE_W3C, $post->post_modified );
-		$this->content['html']  = $this->get_content_by_id( $post->ID );
-		$this->content['value'] = wp_strip_all_tags( $post->post_content );
-		$this->summary          = $this->get_excerpt_by_id( $post->ID );
-		$this->url              = get_permalink( $post->ID );
+		$this->_id  = $post->ID;
+		$this->type = 'entry';
+		$this->name = get_the_title( $post );
+		// Eliminate IDs as names
+		if ( $this->name = $this->_id ) {
+			$this->name = null;
+		}
+		$this->published        = get_post_time( DATE_W3C, false, $post );
+		$this->updated          = get_post_modified_time( DATE_W3C, false, $post );
+		$content = get_the_content( null, false, $post );
+		if ( ! empty( $content ) ) {
+			$this->content['html']  = get_the_content( null, false, $post );
+			$this->content['value'] = wp_strip_all_tags( $this->content['html'] );
+		}
+		$this->summary          = get_the_excerpt( $post );
+		$this->url              = get_permalink( $post );
+		$this->uid              = get_permalink( $post );
 
 		// Get a list of categories and extract their names
 		$post_categories = get_the_terms( $post->ID, 'category' );
@@ -63,15 +72,15 @@ class Mf2_Feed_Entry {
 			foreach ( get_comments( array( 'post_id' => $post->ID ) ) as $post_comment ) {
 				$comment                     = array();
 				$comment['type']             = 'cite';
-				$comment['content']['html']  = $post_comment->comment_content;
-				$comment['content']['value'] = wp_strip_all_tags( $post_comment->comment_content );
-				$comment['published']        = mysql2date( DATE_W3C, $post_comment->comment_date_gmt );
+				$comment['content']['html']  = get_comment_text( $post_comment );
+				$comment['content']['value'] = wp_strip_all_tags( $comment['content']['html'] );
+				$comment['published']        = get_comment_date( DATE_W3C, $post_comment );
 				$comment['author']['type']   = 'card';
-				$comment['author']['name']   = $post_comment->comment_author;
-				$comment['author']['value']  = $post_comment->comment_author;
+				$comment['author']['name']   = get_comment_author( $post_comment );
+				$comment['author']['value']  = $comment['author']['name'];
 
 				if ( $post_comment->comment_author_url ) {
-					$comment['author']['url'] = $post_comment->comment_author_url;
+					$comment['author']['url'] = get_comment_author_url( $post_comment );
 				}
 
 				$this->comment[] = $comment;
@@ -79,52 +88,15 @@ class Mf2_Feed_Entry {
 		}
 	}
 
-	/**
-	 * Display the post content. Optinally allows post ID to be passed
-	 * @uses the_content()
-	 *
-	 * @param int $id Optional. Post ID.
-	 * @param string $more_link_text Optional. Content for when there is more text.
-	 * @param bool $stripteaser Optional. Strip teaser content before the more text. Default is false.
-	 */
-	private function get_content_by_id( $post_id = 0, $more_link_text = null, $stripteaser = false ) {
-		if ( ! $post_id ) {
-			$post_id = get_the_ID();
-		}
-		$post    = get_post( $post_id );
-		$content = get_the_content();
-
-		return $content;
-	}
-
-	/**
-	 * Display the excerpt content. Optinally allows post ID to be passed
-	 * @uses the_content()
-	 *
-	 * @param int $id Optional. Post ID.
-	 * @param string $more_link_text Optional. Content for when there is more text.
-	 * @param bool $stripteaser Optional. Strip teaser content before the more text. Default is false.
-	 */
-	private function get_excerpt_by_id( $post_id = 0, $more_link_text = null, $stripteaser = false ) {
-		if ( ! $post_id ) {
-			$post_id = get_the_ID();
-		}
-		$post    = get_post( $post_id );
-		$content = get_the_excerpt();
-
-		return $content;
-	}
-
 	public function to_mf2() {
 		$entry = apply_filters( 'jf2_entry_array', get_object_vars( $this ), $this->_id );
+		$entry = array_filter( $entry );
 		$entry = apply_filters( 'mf2_entry_array', $this->jf2_to_mf2( $entry ), $this->_id );
-
-		return array_filter( $entry );
+		return $entry;
 	}
 
 	public function to_jf2() {
 		$entry = apply_filters( 'jf2_entry_array', get_object_vars( $this ), $this->_id );
-
 		return array_filter( $entry );
 	}
 

--- a/includes/feed-jf2-comments.php
+++ b/includes/feed-jf2-comments.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * MF2 Feed Template for displaying an JF2 item.
+ *
+ * @package MF2 Feed
+ */
+
+header( 'Content-Type: ' . feed_content_type( 'jf2' ), true );
+
+require_once dirname( __FILE__ ) . '/class-mf2-feed-entry.php';
+$items = array();
+$item  = new Mf2_Feed_Entry( get_the_ID() );
+$items = $item->to_jf2();
+
+// filter output
+$items = apply_filters( 'jf2_feed_array', $items );
+echo Mf2Feed::encode_json( $items );

--- a/includes/feed-jf2-comments.php
+++ b/includes/feed-jf2-comments.php
@@ -9,8 +9,11 @@ header( 'Content-Type: ' . feed_content_type( 'jf2' ), true );
 
 require_once dirname( __FILE__ ) . '/class-mf2-feed-entry.php';
 $items = array();
-$item  = new Mf2_Feed_Entry( get_the_ID() );
-$items = $item->to_jf2();
+$p     = get_post();
+if ( $p ) {
+	$item  = new Mf2_Feed_Entry( $p );
+	$items = $item->to_jf2();
+}
 
 // filter output
 $items = apply_filters( 'jf2_feed_array', $items );

--- a/includes/feed-jf2.php
+++ b/includes/feed-jf2.php
@@ -9,7 +9,16 @@ header( 'Content-Type: ' . feed_content_type( 'jf2feed' ), true );
 
 require_once dirname( __FILE__ ) . '/class-mf2-feed-entry.php';
 
-$items = array( 'type' => 'feed' );
+$items = array(
+	'type'    => 'feed',
+	'name'    => get_bloginfo( 'name' ),
+	'summary' => get_bloginfo( 'description' ),
+	'url'     => get_self_link(),
+);
+if ( ! empty( $featured ) ) {
+	$items['featured'] = $featured;
+}
+
 while ( have_posts() ) {
 	the_post();
 	$item                = new Mf2_Feed_Entry( get_the_ID() );

--- a/includes/feed-jf2.php
+++ b/includes/feed-jf2.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * MF2 Feed Template for displaying an JF2 feed.
+ *
+ * @package MF2 Feed
+ */
+
+header( 'Content-Type: ' . feed_content_type( 'jf2feed' ), true );
+
+require_once dirname( __FILE__ ) . '/class-mf2-feed-entry.php';
+
+$items = array( 'type' => 'feed' );
+while ( have_posts() ) {
+	the_post();
+	$item                = new Mf2_Feed_Entry( get_the_ID() );
+	$items['children'][] = $item->to_jf2();
+}
+
+// filter output
+$items = apply_filters( 'jf2_feed_array', $items );
+echo Mf2Feed::encode_json( $items );

--- a/includes/feed-mf2-comments.php
+++ b/includes/feed-mf2-comments.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * MF2 Feed Template for displaying an MF2 item.
+ *
+ * @package MF2 Feed
+ */
+
+header( 'Content-Type: ' . feed_content_type( 'mf2' ), true );
+
+require_once dirname( __FILE__ ) . '/class-mf2-feed-entry.php';
+$items          = array();
+$item           = new Mf2_Feed_Entry( get_the_ID() );
+$item           = $item->to_mf2();
+$items          = array();
+$items['items'] = $item;
+
+// filter output
+$items = apply_filters( 'mf2_feed_array', $items );
+echo Mf2Feed::encode_json( $items );

--- a/includes/feed-mf2-comments.php
+++ b/includes/feed-mf2-comments.php
@@ -8,11 +8,12 @@
 header( 'Content-Type: ' . feed_content_type( 'mf2' ), true );
 
 require_once dirname( __FILE__ ) . '/class-mf2-feed-entry.php';
-$items          = array();
-$item           = new Mf2_Feed_Entry( get_the_ID() );
-$item           = $item->to_mf2();
-$items          = array();
-$items['items'] = $item;
+$items = array();
+$p     = get_post();
+if ( $p ) {
+	$item           = new Mf2_Feed_Entry( $p );
+	$items['items'] = $item->to_mf2();
+}
 
 // filter output
 $items = apply_filters( 'mf2_feed_array', $items );

--- a/includes/feed-mf2.php
+++ b/includes/feed-mf2.php
@@ -15,11 +15,16 @@ $items = array(
 			'properties' => array(
 				'name'    => array( get_bloginfo( 'name' ) ),
 				'summary' => array( get_bloginfo( 'description' ) ),
-				'url'     => array( site_url( '/' ) ),
+				'url'     => array( get_self_link() ),
 			),
 		),
 	),
 );
+
+$featured = get_site_icon_url();
+if ( ! empty( $featured ) ) {
+	$items['items'][0]['properties']['featured'] = array( $featured );
+}
 
 while ( have_posts() ) {
 	the_post();

--- a/includes/feed-mf2.php
+++ b/includes/feed-mf2.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * MF2 Feed Template for displaying an MF2 feed.
+ *
+ * @package MF2 Feed
+ */
+
+header( 'Content-Type: ' . feed_content_type( 'mf2' ), true );
+
+require_once dirname( __FILE__ ) . '/class-mf2-feed-entry.php';
+$items = array(
+	'items' => array(
+		array(
+			'type'       => array( 'h-feed' ),
+			'properties' => array(
+				'name'    => array( get_bloginfo( 'name' ) ),
+				'summary' => array( get_bloginfo( 'description' ) ),
+				'url'     => array( site_url( '/' ) ),
+			),
+		),
+	),
+);
+
+while ( have_posts() ) {
+	the_post();
+	$item                            = new Mf2_Feed_Entry( get_the_ID() );
+	$items['items'][0]['children'][] = current( $item->to_mf2() );
+}
+
+// filter output
+$items = apply_filters( 'mf2_feed_array', $items );
+echo Mf2Feed::encode_json( $items );

--- a/languages/mf2-feed.pot
+++ b/languages/mf2-feed.pot
@@ -1,10 +1,10 @@
-# Copyright (C) 2020 WordPress Outreach Club
+# Copyright (C) 2020 IndieWeb WordPress Outreach Club
 # This file is distributed under the MIT.
 msgid ""
 msgstr ""
 "Project-Id-Version: MF2 Feed 3.0.0\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/mf2-feed\n"
-"POT-Creation-Date: 2020-01-20 08:46:48+00:00\n"
+"POT-Creation-Date: 2020-01-20 08:57:09+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -26,7 +26,7 @@ msgid "Adds a Microformats2 JSON feed for every entry"
 msgstr ""
 
 #. Author of the plugin/theme
-msgid "WordPress Outreach Club"
+msgid "IndieWeb WordPress Outreach Club"
 msgstr ""
 
 #. Author URI of the plugin/theme

--- a/languages/mf2-feed.pot
+++ b/languages/mf2-feed.pot
@@ -1,17 +1,18 @@
-# Copyright (C) 2018 Matthias Pfefferle
+# Copyright (C) 2019 Matthias Pfefferle
 # This file is distributed under the MIT.
 msgid ""
 msgstr ""
-"Project-Id-Version: MF2 Feed 2.1.0\n"
-"Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/mf2-feed\n"
-"POT-Creation-Date: 2018-11-29 08:49:18+00:00\n"
+"Project-Id-Version: MF2 Feed 3.0.0\n"
+"Report-Msgid-Bugs-To: "
+"https://wordpress.org/support/plugin/wordpress-mf2-feed\n"
+"POT-Creation-Date: 2019-12-30 03:38:36+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"PO-Revision-Date: 2018-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: 2019-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
-"X-Generator: grunt-wp-i18n1.0.2\n"
+"X-Generator: grunt-wp-i18n 1.0.3\n"
 
 #. Plugin Name of the plugin/theme
 msgid "MF2 Feed"

--- a/languages/mf2-feed.pot
+++ b/languages/mf2-feed.pot
@@ -1,18 +1,17 @@
-# Copyright (C) 2019 Matthias Pfefferle
+# Copyright (C) 2020 WordPress Outreach Club
 # This file is distributed under the MIT.
 msgid ""
 msgstr ""
 "Project-Id-Version: MF2 Feed 3.0.0\n"
-"Report-Msgid-Bugs-To: "
-"https://wordpress.org/support/plugin/wordpress-mf2-feed\n"
-"POT-Creation-Date: 2019-12-30 03:38:36+00:00\n"
+"Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/mf2-feed\n"
+"POT-Creation-Date: 2020-01-20 08:46:48+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"PO-Revision-Date: 2019-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: 2020-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
-"X-Generator: grunt-wp-i18n 1.0.3\n"
+"X-Generator: grunt-wp-i18n1.0.2\n"
 
 #. Plugin Name of the plugin/theme
 msgid "MF2 Feed"
@@ -27,9 +26,9 @@ msgid "Adds a Microformats2 JSON feed for every entry"
 msgstr ""
 
 #. Author of the plugin/theme
-msgid "Matthias Pfefferle"
+msgid "WordPress Outreach Club"
 msgstr ""
 
 #. Author URI of the plugin/theme
-msgid "https://notiz.blog/"
+msgid "https://indieweb.org/WordPress_Outreach_Club"
 msgstr ""

--- a/mf2-feed.php
+++ b/mf2-feed.php
@@ -124,10 +124,10 @@ class Mf2Feed {
 <link rel="alternate" type="<?php echo esc_attr( feed_content_type( 'mf2' ) ); ?>" href="<?php echo esc_url( get_post_comments_feed_link( null, 'mf2' ) ); ?>" />
 <link rel="alternate" type="<?php echo esc_attr( feed_content_type( 'jf2' ) ); ?>" href="<?php echo esc_url( get_post_comments_feed_link( null, 'jf2' ) ); ?>" />
 			<?php
-		} elseif ( is_home() ) {
+		} elseif ( ) {
 			?>
 <link rel="alternate" type="<?php echo esc_attr( feed_content_type( 'mf2' ) ); ?>" href="<?php echo esc_url( get_feed_link( 'mf2' ) ); ?>" />
-<link rel="alternate" type="<?php echo esc_attr( feed_content_type( 'jf2' ) ); ?>" href="<?php echo esc_url( get_feed_link( 'jf2' ) ); ?>" />
+<link rel="alternate" type="<?php echo esc_attr( feed_content_type( 'jf2feed' ) ); ?>" href="<?php echo esc_url( get_feed_link( 'jf2' ) ); ?>" />
 			<?php
 		}
 	}

--- a/mf2-feed.php
+++ b/mf2-feed.php
@@ -3,7 +3,7 @@
  * Plugin Name: MF2 Feed
  * Plugin URI: http://github.com/indieweb/wordpress-mf2-feed/
  * Description: Adds a Microformats2 JSON feed for every entry
- * Version: 2.1.0
+ * Version: 3.0.0
  * Author: Matthias Pfefferle
  * Author URI: https://notiz.blog/
  * License: MIT
@@ -124,7 +124,7 @@ class Mf2Feed {
 <link rel="alternate" type="<?php echo esc_attr( feed_content_type( 'mf2' ) ); ?>" href="<?php echo esc_url( get_post_comments_feed_link( null, 'mf2' ) ); ?>" />
 <link rel="alternate" type="<?php echo esc_attr( feed_content_type( 'jf2' ) ); ?>" href="<?php echo esc_url( get_post_comments_feed_link( null, 'jf2' ) ); ?>" />
 			<?php
-		} elseif ( ) {
+		} else {
 			?>
 <link rel="alternate" type="<?php echo esc_attr( feed_content_type( 'mf2' ) ); ?>" href="<?php echo esc_url( get_feed_link( 'mf2' ) ); ?>" />
 <link rel="alternate" type="<?php echo esc_attr( feed_content_type( 'jf2feed' ) ); ?>" href="<?php echo esc_url( get_feed_link( 'jf2' ) ); ?>" />

--- a/mf2-feed.php
+++ b/mf2-feed.php
@@ -1,16 +1,16 @@
 <?php
- /**
-  * Plugin Name: MF2 Feed
-  * Plugin URI: http://github.com/indieweb/wordpress-mf2-feed/
-  * Description: Adds a Microformats2 JSON feed for every entry
-  * Version: 2.1.0
-  * Author: Matthias Pfefferle
-  * Author URI: https://notiz.blog/
-  * License: MIT
-  * License URI: http://opensource.org/licenses/MIT
-  * Text Domain: mf2-feed
-  * Domain Path: /languages
-  */
+/**
+ * Plugin Name: MF2 Feed
+ * Plugin URI: http://github.com/indieweb/wordpress-mf2-feed/
+ * Description: Adds a Microformats2 JSON feed for every entry
+ * Version: 2.1.0
+ * Author: Matthias Pfefferle
+ * Author URI: https://notiz.blog/
+ * License: MIT
+ * License URI: http://opensource.org/licenses/MIT
+ * Text Domain: mf2-feed
+ * Domain Path: /languages
+ */
 
 add_action( 'init', array( 'Mf2Feed', 'init' ) );
 
@@ -62,20 +62,20 @@ class Mf2Feed {
 
 			$post = $post->to_mf2();
 
-			$items            = array();
-			$items['items']   = $post;
+			$items          = array();
+			$items['items'] = $post;
 		} else {
 			$items = array(
-				"items" => array(
+				'items' => array(
 					array(
-						'type' => array( 'h-feed' ),
+						'type'       => array( 'h-feed' ),
 						'properties' => array(
-							'name' => array( get_bloginfo( 'name' ) ),
+							'name'    => array( get_bloginfo( 'name' ) ),
 							'summary' => array( get_bloginfo( 'description' ) ),
-							'url' => array( site_url( '/' ) )
-						)
-					)
-				)
+							'url'     => array( site_url( '/' ) ),
+						),
+					),
+				),
 			);
 
 			while ( have_posts() ) {
@@ -119,7 +119,7 @@ class Mf2Feed {
 		require_once dirname( __FILE__ ) . '/includes/class-mf2-feed-entry.php';
 
 		if ( $for_comments ) {
-			$post = new Mf2_Feed_Entry( get_the_ID(), $for_comments );
+			$post  = new Mf2_Feed_Entry( get_the_ID(), $for_comments );
 			$items = $post->to_jf2();
 		} else {
 			$items = array( 'type' => 'feed' );
@@ -193,15 +193,15 @@ class Mf2Feed {
 	 */
 	public static function add_html_header() {
 		if ( is_singular() ) {
-		?>
+			?>
 <link rel="alternate" type="<?php echo esc_attr( feed_content_type( 'mf2' ) ); ?>" href="<?php echo esc_url( get_post_comments_feed_link( null, 'mf2' ) ); ?>" />
 <link rel="alternate" type="<?php echo esc_attr( feed_content_type( 'jf2' ) ); ?>" href="<?php echo esc_url( get_post_comments_feed_link( null, 'jf2' ) ); ?>" />
-		<?php
-	} elseif ( is_home() ) {
-		?>
+			<?php
+		} elseif ( is_home() ) {
+			?>
 <link rel="alternate" type="<?php echo esc_attr( feed_content_type( 'mf2' ) ); ?>" href="<?php echo esc_url( get_feed_link( 'mf2' ) ); ?>" />
 <link rel="alternate" type="<?php echo esc_attr( feed_content_type( 'jf2' ) ); ?>" href="<?php echo esc_url( get_feed_link( 'jf2' ) ); ?>" />
-		<?php
+			<?php
 		}
 	}
 }

--- a/mf2-feed.php
+++ b/mf2-feed.php
@@ -34,7 +34,6 @@ class Mf2Feed {
 		add_action( 'do_feed_jf2', array( 'Mf2Feed', 'do_feed_jf2' ), 10, 1 );
 
 		add_action( 'wp_head', array( 'Mf2Feed', 'add_html_header' ), 5 );
-		add_filter( 'query_vars', array( 'Mf2Feed', 'query_vars' ) );
 		add_filter( 'feed_content_type', array( 'Mf2Feed', 'feed_content_type' ), 10, 2 );
 	}
 
@@ -55,59 +54,29 @@ class Mf2Feed {
 	 * @param boolean $for_comments true if it is a comment-feed
 	 */
 	public static function do_feed_mf2( $for_comments ) {
-		require_once dirname( __FILE__ ) . '/includes/class-mf2-feed-entry.php';
-
 		if ( $for_comments ) {
-			$post = new Mf2_Feed_Entry( get_the_ID() );
-
-			$post = $post->to_mf2();
-
-			$items          = array();
-			$items['items'] = $post;
+			load_template( dirname( __FILE__ ) . '/includes/feed-mf2-comments.php' );
 		} else {
-			$items = array(
-				'items' => array(
-					array(
-						'type'       => array( 'h-feed' ),
-						'properties' => array(
-							'name'    => array( get_bloginfo( 'name' ) ),
-							'summary' => array( get_bloginfo( 'description' ) ),
-							'url'     => array( site_url( '/' ) ),
-						),
-					),
-				),
-			);
-
-			while ( have_posts() ) {
-				the_post();
-
-				$post = new Mf2_Feed_Entry( get_the_ID() );
-
-				$items['items'][0]['children'][] = current( $post->to_mf2() );
-			}
+			load_template( dirname( __FILE__ ) . '/includes/feed-mf2.php' );
 		}
+	}
 
-		// filter output
-		$json = apply_filters( 'mf2_feed_array', $items );
-
-		header( 'Content-Type: ' . feed_content_type( 'mf2' ) . '; charset=' . get_option( 'blog_charset' ), true );
-
-		$options = 0;
-		// JSON_PRETTY_PRINT added in PHP 5.4
-		if ( get_query_var( 'pretty' ) ) {
-			$options |= JSON_PRETTY_PRINT;
-		}
-
+	/**
+	 * Prepares JSON for output
+	 *
+	 * @param array $json Associative array
+	 * @return string $json_str JSON encoded string
+	 */
+	public static function encode_json( $json, $feed = 'mf2' ) {
+		$options |= JSON_PRETTY_PRINT;
 		/*
 		 * Options to be passed to json_encode()
 		 *
 		 * @param int $options The current options flags
 		 */
-		$options = apply_filters( 'mf2_feed_options', $options );
+		$options = apply_filters( '{$feed}_feed_options', $options ); // phpcs:ignore
 
-		$json_str = wp_json_encode( $json, $options );
-
-		echo $json_str;
+		return wp_json_encode( $json, $options );
 	}
 
 	/**
@@ -116,44 +85,12 @@ class Mf2Feed {
 	 * @param boolean $for_comments true if it is a comment-feed
 	 */
 	public static function do_feed_jf2( $for_comments ) {
-		require_once dirname( __FILE__ ) . '/includes/class-mf2-feed-entry.php';
-
 		if ( $for_comments ) {
-			$post  = new Mf2_Feed_Entry( get_the_ID(), $for_comments );
-			$items = $post->to_jf2();
+			load_template( dirname( __FILE__ ) . '/includes/feed-jf2-comments.php' );
 		} else {
-			$items = array( 'type' => 'feed' );
-
-			while ( have_posts() ) {
-				the_post();
-
-				$post                = new Mf2_Feed_Entry( get_the_ID() );
-				$items['children'][] = $post->to_jf2();
-			}
+			load_template( dirname( __FILE__ ) . '/includes/feed-jf2.php' );
 		}
-
-		// filter output
-		$json = apply_filters( 'jf2_feed_array', $items );
-
-		header( 'Content-Type: ' . feed_content_type( 'jf2' ) . '; charset=' . get_option( 'blog_charset' ), true );
-
-		$options = 0;
-
-		// JSON_PRETTY_PRINT added in PHP 5.4
-		if ( get_query_var( 'pretty' ) ) {
-			$options |= JSON_PRETTY_PRINT;
-		}
-
-		/*
-		 * Options to be passed to json_encode()
-		 *
-		 * @param int $options The current options flags
-		 */
-		$options = apply_filters( 'jf2_feed_options', $options );
-
-		$json_str = wp_json_encode( $json, $options );
-
-		echo $json_str;
+		require_once dirname( __FILE__ ) . '/includes/class-mf2-feed-entry.php';
 	}
 
 	/**
@@ -171,19 +108,11 @@ class Mf2Feed {
 		if ( 'jf2' === $type || 'jf2' === $type ) {
 			return apply_filters( 'jf2_feed_content_type', 'application/jf2+json' );
 		}
+		if ( 'jf2feed' === $type || 'jf2feed' === $type ) {
+			return apply_filters( 'jf2_feed_content_type', 'application/jf2feed+json' );
+		}
 
 		return $content_type;
-	}
-
-	/**
-	 * add 'pretty' as a valid query variables.
-	 *
-	 * @param array $vars
-	 * @return array
-	 */
-	public static function query_vars( $vars ) {
-		$vars[] = 'pretty';
-		return $vars;
 	}
 
 	/**

--- a/mf2-feed.php
+++ b/mf2-feed.php
@@ -68,7 +68,7 @@ class Mf2Feed {
 	 * @return string $json_str JSON encoded string
 	 */
 	public static function encode_json( $json, $feed = 'mf2' ) {
-		$options |= JSON_PRETTY_PRINT;
+		$options = JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES;
 		/*
 		 * Options to be passed to json_encode()
 		 *
@@ -90,7 +90,6 @@ class Mf2Feed {
 		} else {
 			load_template( dirname( __FILE__ ) . '/includes/feed-jf2.php' );
 		}
-		require_once dirname( __FILE__ ) . '/includes/class-mf2-feed-entry.php';
 	}
 
 	/**

--- a/mf2-feed.php
+++ b/mf2-feed.php
@@ -4,8 +4,8 @@
  * Plugin URI: http://github.com/indieweb/wordpress-mf2-feed/
  * Description: Adds a Microformats2 JSON feed for every entry
  * Version: 3.0.0
- * Author: Matthias Pfefferle
- * Author URI: https://notiz.blog/
+ * Author: WordPress Outreach Club
+ * Author URI: https://indieweb.org/WordPress_Outreach_Club
  * License: MIT
  * License URI: http://opensource.org/licenses/MIT
  * Text Domain: mf2-feed

--- a/mf2-feed.php
+++ b/mf2-feed.php
@@ -132,3 +132,12 @@ class Mf2Feed {
 		}
 	}
 }
+
+// Backcompat for function introduced in WordPress 5.3
+if ( ! function_exists( 'get_self_link' ) ) {
+	function get_self_link() {
+		$host = @parse_url( home_url() );
+		return set_url_scheme( 'http://' . $host['host'] . wp_unslash( $_SERVER['REQUEST_URI'] ) );
+	}
+}
+

--- a/mf2-feed.php
+++ b/mf2-feed.php
@@ -176,15 +176,13 @@ class Mf2Feed {
 	}
 
 	/**
-	 * add 'feed' and 'pretty' as a valid query variables.
+	 * add 'pretty' as a valid query variables.
 	 *
 	 * @param array $vars
 	 * @return array
 	 */
 	public static function query_vars( $vars ) {
-		$vars[] = 'feed';
 		$vars[] = 'pretty';
-
 		return $vars;
 	}
 

--- a/mf2-feed.php
+++ b/mf2-feed.php
@@ -4,7 +4,7 @@
  * Plugin URI: http://github.com/indieweb/wordpress-mf2-feed/
  * Description: Adds a Microformats2 JSON feed for every entry
  * Version: 3.0.0
- * Author: WordPress Outreach Club
+ * Author: IndieWeb WordPress Outreach Club
  * Author URI: https://indieweb.org/WordPress_Outreach_Club
  * License: MIT
  * License URI: http://opensource.org/licenses/MIT

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0"?>
-<ruleset name="WordPress Indieauth">
-	<description>WordPress Indieauth Standards</description>
+<ruleset name="WordPress MF2 Feed">
+	<description>WordPress MF2 Feed Standards</description>
 
-	<file>./indieauth.php</file>
+	<file>./mf2-feed.php</file>
 	<file>./includes/</file>
 	<exclude-pattern>*/includes/*\.(inc|css|js|svg)</exclude-pattern>
 	<exclude-pattern>*/vendor/*</exclude-pattern>
 	<rule ref="PHPCompatibility"/>
-	<config name="testVersion" value="5.3-"/>
+	<config name="testVersion" value="5.6-"/>
 	<rule ref="PHPCompatibilityWP"/>
-	<config name="minimum_supported_wp_version" value="4.7"/>
+	<config name="minimum_supported_wp_version" value="4.9"/>
 	<rule ref="WordPress.WP.DeprecatedFunctions" />
 	<rule ref="WordPress-Core" />
 	<rule ref="WordPress.Files.FileName">
@@ -20,5 +20,5 @@
 
 	<rule ref="WordPress-Extra" />
 	<rule ref="WordPress.WP.I18n"/>
-	<config name="text_domain" value="indieauth,default"/>
+	<config name="text_domain" value="mf2-feed,default"/>
 </ruleset>

--- a/readme.md
+++ b/readme.md
@@ -1,21 +1,22 @@
 # MF2 Feeds #
-**Contributors:** [pfefferle](https://profiles.wordpress.org/pfefferle), [indieweb](https://profiles.wordpress.org/indieweb)  
+**Contributors:** [pfefferle](https://profiles.wordpress.org/pfefferle), [dshanske](https://profiles.wordpress.org/dshanske), [indieweb](https://profiles.wordpress.org/indieweb)  
 **Donate link:** https://notiz.blog/donate/  
 **Tags:** microformats, mf2, jf2, rel-alternate, indieweb  
-**Requires at least:** 4.7  
-**Tested up to:** 4.9.8  
-**Stable tag:** 2.1.0  
-**Requires PHP:** 5.3  
+**Requires at least:** 5.2  
+**Tested up to:** 5.3.2  
+**Stable tag:** 3.0.0  
+**Requires PHP:** 5.6  
 **License:** MIT  
 **License URI:** http://opensource.org/licenses/MIT  
 
-Microformats2 Feeds for WordPress
+Add Microformats2 Feeds for WordPress
 
 ## Description ##
 
-[Microformats2](https://indieweb.org/microformats) are a key [building-block](https://indieweb.org/Category:building-blocks) of the IndieWeb, but it is very hard (if not impossible) to get Microformats2 as a core feature for all WordPress themes. There are several themes that are supporting Microformats2, but everyone should choose his prefered theme and should not be limited to use one of the [few community themes](https://indieweb.org/WordPress/Themes). After [a lot of discussions](https://github.com/indieweb/wordpress-uf2/issues/30) and some different plugin approaches, we are trying to provide an alternate ([`rel=altenate`](https://indieweb.org/rel-alternate)) representation of the microformatted HTML.
+Provides a [Microformats2 JSON](http://microformats.org/wiki/microformats2-parsing) "Feed" for every WordPress URL, and helps to allow other sites to get pre-parsed [Microformats-JSON](https://indieweb.org/jf2) even if the theme 
+does not support Microformats2.                
 
-The `mf2-feed` plugin provides a [Microformats2 JSON](http://microformats.org/wiki/microformats2-parsing) "Feed" for every WordPress URL, and helps to get a pre-parsed [Microformats-JSON](https://indieweb.org/jf2) even if the theme does not support Microformats2.
+[Microformats2](https://indieweb.org/microformats) are a key [building-block](https://indieweb.org/Category:building-blocks) of the IndieWeb, but it is very hard (if not impossible) to get Microformats2 as a core feature for all WordPress themes. There are several themes that are supporting Microformats2, but everyone should choose his prefered theme and should not be limited to use one of the [few community themes](https://indieweb.org/WordPress/Themes). After [a lot of discussions](https://github.com/indieweb/wordpress-uf2/issues/30) and some different plugin approaches, we are trying to provide an alternate ([`rel=altenate`](https://indieweb.org/rel-alternate)) representation of the microformatted HTML.
 
 The plugin is inspired by the URL design of [p3k](https://github.com/aaronpk/p3k) of [@aaronpk](https://github.com/aaronpk).
 
@@ -35,7 +36,7 @@ WordPress Example:
 
 ### What are Microformats 2? ###
 
-Microformats are a simple way to markup structured information in HTML. WordPress incorporates some classic Microformats. Microformats 2 supersedes class microformats.
+Microformats are a simple way to markup structured information in HTML using classes. WordPress incorporates some classic Microformats. Microformats 2 supersedes classic microformats.
 
 ## Installation ##
 
@@ -78,6 +79,15 @@ To install a WordPress Plugin manually:
 ## Changelog ##
 
 Project actively developed on Github at [indieweb/wordpress-mf2-feed](https://github.com/indieweb/wordpress-mf2-feed). Please file support issues there.
+
+### 3.0.0 ###
+* Refactored to match the configuration of feeds built into WordPress
+* Bumped PHP Version requirement to PHP5.6 to match WordPress 5.3
+* Bumped minimum WordPress version to 5.2 as this allows for the version of get_content that includes a $post parameter
+* Fixed incorrect PHPCS configuration
+* Enabled JSON Pretty Print by default as originally disabled due a PHP5.4 requirement
+* Changed Post Item Generation Class to use WordPress functions instead of directly accessing the data where applicable
+* Adjusted jf2 feed to comply with jf2feed spec (https://jf2.spec.indieweb.org/#jf2feed)
 
 ### 2.1.0 ###
 

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # MF2 Feeds #
 **Contributors:** [pfefferle](https://profiles.wordpress.org/pfefferle), [dshanske](https://profiles.wordpress.org/dshanske), [indieweb](https://profiles.wordpress.org/indieweb)  
-**Donate link:** https://notiz.blog/donate/  
+**Donate link:** https://opencollective.com/indieweb  
 **Tags:** microformats, mf2, jf2, rel-alternate, indieweb  
 **Requires at least:** 5.2  
 **Tested up to:** 5.3.2  
@@ -13,8 +13,8 @@ Add Microformats2 Feeds for WordPress
 
 ## Description ##
 
-Provides a [Microformats2 JSON](http://microformats.org/wiki/microformats2-parsing) "Feed" for every WordPress URL, and helps to allow other sites to get pre-parsed [Microformats-JSON](https://indieweb.org/jf2) even if the theme 
-does not support Microformats2.                
+Provides a [Microformats2 JSON](http://microformats.org/wiki/microformats2-parsing) "Feed" for every WordPress URL, and helps to allow other sites to get pre-parsed [Microformats-JSON](https://indieweb.org/jf2) even if the theme
+does not support Microformats2.
 
 [Microformats2](https://indieweb.org/microformats) are a key [building-block](https://indieweb.org/Category:building-blocks) of the IndieWeb, but it is very hard (if not impossible) to get Microformats2 as a core feature for all WordPress themes. There are several themes that are supporting Microformats2, but everyone should choose his prefered theme and should not be limited to use one of the [few community themes](https://indieweb.org/WordPress/Themes). After [a lot of discussions](https://github.com/indieweb/wordpress-uf2/issues/30) and some different plugin approaches, we are trying to provide an alternate ([`rel=altenate`](https://indieweb.org/rel-alternate)) representation of the microformatted HTML.
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,21 +1,22 @@
 === MF2 Feeds ===
-Contributors: pfefferle, indieweb
+Contributors: pfefferle, dshanske, indieweb
 Donate link: https://notiz.blog/donate/
 Tags: microformats, mf2, jf2, rel-alternate, indieweb
-Requires at least: 4.7
-Tested up to: 4.9.8
-Stable tag: 2.1.0
-Requires PHP: 5.3
+Requires at least: 5.2
+Tested up to: 5.3.2
+Stable tag: 3.0.0
+Requires PHP: 5.6
 License: MIT
 License URI: http://opensource.org/licenses/MIT
 
-Microformats2 Feeds for WordPress
+Add Microformats2 Feeds for WordPress
 
 == Description ==
 
-[Microformats2](https://indieweb.org/microformats) are a key [building-block](https://indieweb.org/Category:building-blocks) of the IndieWeb, but it is very hard (if not impossible) to get Microformats2 as a core feature for all WordPress themes. There are several themes that are supporting Microformats2, but everyone should choose his prefered theme and should not be limited to use one of the [few community themes](https://indieweb.org/WordPress/Themes). After [a lot of discussions](https://github.com/indieweb/wordpress-uf2/issues/30) and some different plugin approaches, we are trying to provide an alternate ([`rel=altenate`](https://indieweb.org/rel-alternate)) representation of the microformatted HTML.
+Provides a [Microformats2 JSON](http://microformats.org/wiki/microformats2-parsing) "Feed" for every WordPress URL, and helps to allow other sites to get pre-parsed [Microformats-JSON](https://indieweb.org/jf2) even if the theme 
+does not support Microformats2.                
 
-The `mf2-feed` plugin provides a [Microformats2 JSON](http://microformats.org/wiki/microformats2-parsing) "Feed" for every WordPress URL, and helps to get a pre-parsed [Microformats-JSON](https://indieweb.org/jf2) even if the theme does not support Microformats2.
+[Microformats2](https://indieweb.org/microformats) are a key [building-block](https://indieweb.org/Category:building-blocks) of the IndieWeb, but it is very hard (if not impossible) to get Microformats2 as a core feature for all WordPress themes. There are several themes that are supporting Microformats2, but everyone should choose his prefered theme and should not be limited to use one of the [few community themes](https://indieweb.org/WordPress/Themes). After [a lot of discussions](https://github.com/indieweb/wordpress-uf2/issues/30) and some different plugin approaches, we are trying to provide an alternate ([`rel=altenate`](https://indieweb.org/rel-alternate)) representation of the microformatted HTML.
 
 The plugin is inspired by the URL design of [p3k](https://github.com/aaronpk/p3k) of [@aaronpk](https://github.com/aaronpk).
 
@@ -35,7 +36,7 @@ WordPress Example:
 
 = What are Microformats 2? =
 
-Microformats are a simple way to markup structured information in HTML. WordPress incorporates some classic Microformats. Microformats 2 supersedes class microformats.
+Microformats are a simple way to markup structured information in HTML using classes. WordPress incorporates some classic Microformats. Microformats 2 supersedes classic microformats.
 
 == Installation ==
 
@@ -78,6 +79,15 @@ To install a WordPress Plugin manually:
 == Changelog ==
 
 Project actively developed on Github at [indieweb/wordpress-mf2-feed](https://github.com/indieweb/wordpress-mf2-feed). Please file support issues there.
+
+= 3.0.0 =
+* Refactored to match the configuration of feeds built into WordPress
+* Bumped PHP Version requirement to PHP5.6 to match WordPress 5.3
+* Bumped minimum WordPress version to 5.2 as this allows for the version of get_content that includes a $post parameter
+* Fixed incorrect PHPCS configuration
+* Enabled JSON Pretty Print by default as originally disabled due a PHP5.4 requirement
+* Changed Post Item Generation Class to use WordPress functions instead of directly accessing the data where applicable
+* Adjusted jf2 feed to comply with jf2feed spec (https://jf2.spec.indieweb.org/#jf2feed)
 
 = 2.1.0 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === MF2 Feeds ===
 Contributors: pfefferle, dshanske, indieweb
-Donate link: https://notiz.blog/donate/
+Donate link: https://opencollective.com/indieweb
 Tags: microformats, mf2, jf2, rel-alternate, indieweb
 Requires at least: 5.2
 Tested up to: 5.3.2
@@ -13,8 +13,8 @@ Add Microformats2 Feeds for WordPress
 
 == Description ==
 
-Provides a [Microformats2 JSON](http://microformats.org/wiki/microformats2-parsing) "Feed" for every WordPress URL, and helps to allow other sites to get pre-parsed [Microformats-JSON](https://indieweb.org/jf2) even if the theme 
-does not support Microformats2.                
+Provides a [Microformats2 JSON](http://microformats.org/wiki/microformats2-parsing) "Feed" for every WordPress URL, and helps to allow other sites to get pre-parsed [Microformats-JSON](https://indieweb.org/jf2) even if the theme
+does not support Microformats2.
 
 [Microformats2](https://indieweb.org/microformats) are a key [building-block](https://indieweb.org/Category:building-blocks) of the IndieWeb, but it is very hard (if not impossible) to get Microformats2 as a core feature for all WordPress themes. There are several themes that are supporting Microformats2, but everyone should choose his prefered theme and should not be limited to use one of the [few community themes](https://indieweb.org/WordPress/Themes). After [a lot of discussions](https://github.com/indieweb/wordpress-uf2/issues/30) and some different plugin approaches, we are trying to provide an alternate ([`rel=altenate`](https://indieweb.org/rel-alternate)) representation of the microformatted HTML.
 


### PR DESCRIPTION
This plugin had not been updated in a year and was in need of some refreshing. This fixes the PHPCS configuratioin, which appears to have been copied without modification from the IndieAuth plugin. Also, WordPress 5.2 now allows for $post to be passed into get_the_content... so simplified several areas.

Also, used the feed-??? format that is used by WordPress feeds elsewhere to match more closely.

